### PR TITLE
ポップアップ機能の改修

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -36,5 +36,8 @@
     },
     "default_title": "KUPlus",
     "default_popup": "pages/popup.html"
-  }
+  },
+  "permissions": [
+    "tabs"
+  ]
 }

--- a/public/pages/popup.html
+++ b/public/pages/popup.html
@@ -15,7 +15,6 @@
         <button href="https://www.g.k.kyoto-u.ac.jp/shibboleth/index.php">GORILLA</button>
     </div>
 
-    <script src="../scripts/vendor.bundle.js"></script>
     <script src="../scripts/popup.bundle.js"></script>
   </body>
 </html>

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -2,7 +2,16 @@ window.onload = () => {
   document.querySelectorAll(".container button").forEach((b) => {
     b.addEventListener('click', (e) => {
       const url = b.getAttribute("href") || 'http://www.kyoto-u.ac.jp';
-      chrome.tabs.create({url});
+
+      // 新規タブページにいたら、新しくタブを開かない
+      chrome.tabs.query({active: true, currentWindow: true}, (tabs) => {
+        if (tabs.length > 0 && tabs[0].url === 'chrome://newtab/') {
+          chrome.tabs.update({url});
+          window.close();
+        } else {
+          chrome.tabs.create({url});
+        }
+      });
       return false;
     });
   });

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,8 +1,9 @@
-import $ from 'jquery';
-
-$(function() {
-    $(".container button").click(function() {
-        chrome.tabs.create({"url": $(this).attr("href")});
-        return false;
+window.onload = () => {
+  document.querySelectorAll(".container button").forEach((b) => {
+    b.addEventListener('click', (e) => {
+      const url = b.getAttribute("href") || 'http://www.kyoto-u.ac.jp';
+      chrome.tabs.create({url});
+      return false;
     });
-});
+  });
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,6 @@ module.exports = {
     extensions: ['.ts', '.js']
   },
   plugins: [
-    new CleanWebpackPlugin(),
     new CopyPlugin([
       {from: './public', to: './'},
     ]),


### PR DESCRIPTION
- jQueryの使用している部分をやめ、標準DOM操作に置き換え
- `chrome://newtab/` にいたら、新たにタブを作らない ( fix #12 )